### PR TITLE
Fix broken test for 5.7

### DIFF
--- a/innotop
+++ b/innotop
@@ -1195,7 +1195,7 @@ sub parse_lg_section {
    ( $section->{ 'last_chkp' } )
       = $fulltext =~ m/Last checkpoint at \s*(\d.*)$/m;
    @{$section}{ 'pending_log_writes', 'pending_chkp_writes' }
-      = $fulltext =~ m/$d pending log writes, $d pending chkp writes/;
+      = $fulltext =~ m/$d pending log (?:writes|flushes), $d pending chkp writes/;
    @{$section}{ 'log_ios_done', 'log_ios_s' }
       = $fulltext =~ m#$d log i/o's done, $f log i/o's/second#;
 

--- a/t/InnoDBParser.t
+++ b/t/InnoDBParser.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings FATAL => 'all';
 use English qw(-no_match_vars);
-use Test::More tests => 5;
+use Test::More tests => 6;
 use Data::Dumper;
 
 my $path;
@@ -33,7 +33,7 @@ my %versions = (
    $path . 't/innodb-status-006' => "5.5or-earlier",
    $path . 't/innodb-status-007' => "5.5or-earlier",
    $path . 't/innodb-status-008' => "5.6.12",
-   $path . 't/innodb-status-008' => "5.7"
+   $path . 't/innodb-status-009' => "5.7.7"
 );
 
 my %tests = (
@@ -1977,7 +1977,7 @@ my %tests = (
     IB_bp_buf_pool_hits => '1000',
     IB_bp_buf_pool_reads => '1000',
     IB_bp_buf_pool_size => '8191',
-    IB_bp_complete => '122157',
+    IB_bp_complete => '1',
     IB_bp_dict_mem_alloc => '130760',
     IB_bp_page_creates_sec => '0.05',
     IB_bp_page_reads_sec => '1.01',
@@ -2021,9 +2021,9 @@ my %tests = (
     IB_ib_hash_searches_s => '0.00',
     IB_ib_hash_table_size => '276671',
     IB_ib_inserts => undef,
-    IB_ib_merged_recs => 56536,
-    IB_ib_merges => 56536,
-    IB_ib_non_hash_searches_s => '1.06',
+    IB_ib_merged_recs => '0',
+    IB_ib_merges => '0',
+    IB_ib_non_hash_searches_s => '0.07',
     IB_ib_seg_size => '43',
     IB_ib_size => '1',
     IB_ib_used_cells => undef,
@@ -2141,10 +2141,10 @@ my %tests = (
     IB_sm_rw_excl_spins => '7253812',
     IB_sm_rw_shared_os_waits => '233780815',
     IB_sm_rw_shared_spins => '326628200',
-    IB_sm_signal_count => '195748281',
+    IB_sm_signal_count => undef,
     IB_sm_wait_array_size => 0,
     IB_sm_waits => [],
-    IB_timestring => '2013-06-19 13:47:37',
+    IB_timestring => '2015-06-09 13:52:05',
     IB_tx_complete => 1,
     IB_tx_history_list_len => '2401',
     IB_tx_is_truncated => 0,
@@ -2155,7 +2155,7 @@ my %tests = (
       {
         active_secs => 0,
         has_read_view => 0,
-        heap_size => 0,
+        heap_size => '1152',
         hostname => 'localhost',
         ip => '',
         lock_structs => 0,


### PR DESCRIPTION
# Summary
- Test expected values introduced by #114 are wrong.

# Specified details
- innotop:1198
  - 5.7 changes pending log `flushes` from `writes`
  - https://github.com/innotop/innotop/blob/master/t/innodb-status-009#L70
- t/InnoDBParser.t:5
  - Mistaken simply.
- t/InnoDBParser.t:36
  1. File name is wrong.
  2. `$mysqlversion` is expected `x.y.` (x dot y dot) style.
    - https://github.com/innotop/innotop/blob/master/innotop#L474
- t/InnoDBParser.t:2024, 2025, 2144
  - ib_merged_recs, ib_merged, sm_signal_count had not been parsed since MySQL 5.6.
    - https://github.com/innotop/innotop/blob/master/t/InnoDBParser.t#L1811-L1812
    - https://github.com/innotop/innotop/blob/master/t/InnoDBParser.t#L1931