### PR TITLE
Only include the first three numbers in the version string

### DIFF
--- a/innotop
+++ b/innotop
@@ -7655,7 +7655,7 @@ sub connect_to_db {
 # Compares versions like 5.0.27 and 4.1.15-standard-log
 sub version_ge {
    my ( $dbh, $target ) = @_;
-   my $version = sprintf('%03d%03d%03d', $dbh->{mysql_serverinfo} =~ m/(\d+)/g);
+   my $version = sprintf('%03d%03d%03d', ($dbh->{mysql_serverinfo} =~ m/(\d+)/g)[0..2]);
    return $version ge sprintf('%03d%03d%03d', $target =~ m/(\d+)/g);
 }
 


### PR DESCRIPTION
My Percona server identifies itself as:

```
Server version: 5.6.30-76.3 Percona Server (GPL), Release 76.3, Revision 3850db5
```

Because there are five groups of numbers instead of the customary three, I get this error on start up:

```
localhost PROCESSLIST_NO_IS: Redundant argument in sprintf at ./innotop line 7658.
```

This pull request only uses the first three numbers when comparing version numbers.
