### PR TITLE
Update innotop version in innotop.spec

### DIFF
--- a/innotop.spec
+++ b/innotop.spec
@@ -3,7 +3,7 @@
 #
 Name:      innotop
 Summary:   A MySQL and InnoDB monitor program.
-Version:   1.10.0
+Version:   1.11.1
 Release:   1%{?dist}
 Vendor:    Baron Schwartz <baron@percona.com>
 Packager:  Frederic Descamps <lefred@percona.com>


### PR DESCRIPTION
The version in the spec file was not updated so rpmbuild fails since it cannot find the matching tar file.
