### PR TITLE
Fix Perl strict error

### DIFF
--- a/innotop
+++ b/innotop
@@ -4196,6 +4196,7 @@ eval {
 if ( $EVAL_ERROR || $opts{n} ) {
    # If there was an error, manufacture my own colored() function that does no
    # coloring.
+   undef &colored;
    *colored = sub { pop @_; @_; };
 }
 


### PR DESCRIPTION
#153 Undefine function before redefining to avoid Perl fatal error (warning as strict).