### PR TITLE
fix license declaration

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -4,17 +4,18 @@ Source: <https://github.com/innotop/innotop>
 
 Files: *
 Copyright: 200?-2017 many authors
-License: GPL-2.0+
+License: GPL-2.0-only or Artistic-1.0-Perl
 
 Files: debian/*
 Copyright: 2017 unknown <eslocombe@gmail.com>
 License: GPL-2.0+
 
-License: GPL-2.0+
- This package is free software; you can redistribute it and/or modify
- it under the terms of the GNU General Public License as published by
- the Free Software Foundation; either version 2 of the License, or
- (at your option) any later version.
+License: GPL-2.0-only or Artistic-1.0-Perl
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation, version 2; OR the Perl Artistic License.  On UNIX and similar
+ systems, you can issue `man perlgpl' or `man perlartistic' to read these
+ licenses.
  .
  This package is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of


### PR DESCRIPTION
👋  it looks like the debian license declaration is inconsistent with the license header in `innotop`, thus proposing to make they mean the same thing. 

kind of relates to https://github.com/Homebrew/homebrew-core/pull/66699