### PR TITLE
Adding suport for --ssl_optional option

### DIFF
--- a/innotop
+++ b/innotop
@@ -1441,6 +1441,7 @@ my @opt_spec = (
    { s => 'socket|S=s', d => 'MySQL socket to use for connection' },
    { s => 'timestamp|t+', d => 'Print timestamp in -n mode (1: per iter; 2: per line)' },
    { s => 'ssl', d => 'Passed to mysql_ssl', c => 'mysql_ssl' },
+   { s => 'ssl_optional', d => 'Passed to mysql_ssl_optional', c => 'mysql_ssl_optional' },
    { s => 'ssl_ca_file=s', d => 'Passed to mysql_ssl_ca_file', c => 'mysql_ssl_ca_file' },
    { s => 'ssl_ca_path=s', d => 'Passed to mysql_ssl_ca_path', c => 'mysql_ssl_ca_path' },
    { s => 'ssl_verify_server_cert', d => 'Passed to mysql_ssl_verify_server_cert', c => 'mysql_ssl_verify_server_cert' },
@@ -7731,6 +7732,7 @@ sub get_new_db_connection {
       PrintError        => 0,
    };
    $defaults->{mysql_ssl} = $opts{ssl} if $opts{ssl};
+   $defaults->{mysql_ssl_optional} = $opts{ssl_optional} if $opts{ssl_optional};
    $defaults->{mysql_ssl_ca_file} = $opts{ssl_ca_file} if $opts{ssl_ca_file};
    $defaults->{mysql_ssl_ca_path} = $opts{ssl_ca_path} if $opts{ssl_ca_path};
    $defaults->{mysql_ssl_verify_server_cert} = $opts{ssl_verify_server_cert} if $opts{ssl_verify_server_cert};


### PR DESCRIPTION
If you want to connect to MySQL that requires SSL, but without verifying server certificate - combination of `--ssl` and `--ssl_optional` is required.  
Combination of `mysql_ssl=1` and `ssl_verify_server_cert=0` causes error: `Enforcing SSL encryption is not supported without mysql_ssl_verify_server_cert=1`. Only with `mysql_ssl_optional=1` connection is successfully established.