### PR TITLE
Changes in modern terminology handling and MySQL Version Checks

### DIFF
--- a/innotop
+++ b/innotop
@@ -4688,14 +4688,14 @@ my %stmt_maker_for = (
    },
    SHOW_MASTER_LOGS => sub {
       my ( $dbh ) = @_;
-      return $dbh->prepare(version_ge( $dbh, '8.0.34' ) && !version_ge( $dbh, '10.0.0' )
+      return $dbh->prepare(version_ge( $dbh, '8.1' ) && !version_ge( $dbh, '10.0.0' )
            ? 'SHOW /*innotop*/ BINARY LOGS'
            : 'SHOW /*innotop*/ MASTER LOGS');
    },
    SHOW_MASTER_STATUS => sub {
       my ( $dbh ) = @_;
       return $dbh->prepare(version_ge( $dbh, '8.0.34' ) && !version_ge( $dbh, '10.0.0' )
-           ? 'SHOW /*innotop*/ BINARY LOG STATUS'
+           ? 'SHOW /*innotop*/ MASTER STATUS'
            : 'SHOW /*innotop*/ MASTER STATUS');
    },
    SHOW_SLAVE_STATUS => sub {
@@ -9495,8 +9495,11 @@ sub get_status_info {
             my @prev_run = ($pre->{SPARK_store_run} || '') =~ m/(\S+)/g;
 
             # Find out the values; throw away if too many; sparkify; store.
-            my $this_qps = (($vars->{Queries} || 0) - ($pre->{Queries} || 0))/
+            my $this_qps = 0;
+            if ($vars->{Uptime_hires} - $pre->{Uptime_hires} > 0) {
+               $this_qps = (($vars->{Queries} || 0) - ($pre->{Queries} || 0))/
                            ($vars->{Uptime_hires} - $pre->{Uptime_hires});
+            }
             push @prev_qps, $this_qps;
             shift @prev_qps if @prev_qps > $config{spark}->{val};
             my $qps_spark = sparkify(@prev_qps);
@@ -9960,6 +9963,20 @@ sub get_slave_status {
          	my $res = $stmt->fetchall_arrayref({});
        	   if ( $res && @$res ) {
        	    	$res = $res->[0];
+
+               # patch terminology
+               foreach my $key (keys %$res) {
+                  if ($key =~ /^replica_/) {
+                     my $new_key = $key;
+                     $new_key =~ s/^replica_/slave_/;
+                     $res->{$new_key} = delete $res->{$key};
+                  } elsif ($key =~ /^source_/) {
+                     my $new_key = $key;
+                     $new_key =~ s/^source_/master_/;
+                     $res->{$new_key} = delete $res->{$key};
+                  }
+               }
+
        	    	@{$vars}{ keys %$res } = values %$res;
             	$vars->{Slave_ok} =
                		(($res->{slave_sql_running} || 'Yes') eq 'Yes'
@@ -9970,7 +9987,13 @@ sub get_slave_status {
            }
   	 } else {
 				 my $dbh = connect_to_db($cxn);
-				 my $sql = 'SHOW SLAVE STATUS FOR CHANNEL \'' . $channel . '\''; 
+             my $use_new_terms = version_ge($dbh, '8.0.34') && !version_ge($dbh, '10.0');
+             my $sql;
+				 if ($use_new_terms) {
+                  $sql = 'SHOW REPLICA STATUS FOR CHANNEL \'' . $channel . '\'';
+            } else {
+               $sql = 'SHOW SLAVE STATUS FOR CHANNEL \'' . $channel . '\'';
+             }
 				 my $stmt = $dbh->prepare($sql ) ;
 				 $stmt->execute();
          		 my $res = $stmt->fetchall_arrayref({});

--- a/innotop.spec
+++ b/innotop.spec
@@ -3,7 +3,7 @@
 #
 Name:      innotop
 Summary:   A MySQL and InnoDB monitor program.
-Version:   1.15.0
+Version:   1.15.1
 Release:   1%{?dist}
 Vendor:    Baron Schwartz <baron@percona.com>
 Packager:  Frederic Descamps <lefred@percona.com>


### PR DESCRIPTION
This pull request corrects errors in classic replication for older versions of MySQL that were [introduced](https://github.com/innotop/innotop/pull/203) when implementing group replication support.

1.	Updated version check logic in SHOW_MASTER_LOGS and SHOW_MASTER_STATUS to correctly handle MySQL 8.1 and above.
2.	Added a zero division check for the $this_qps variable in the get_status_info function.
3.	In the get_slave_status function:
	•	Added renaming of variables from replica_ to slave_ and from source_ to master_ to support the new terminology.
	•	Added a version range check for MySQL to use the correct query (SHOW REPLICA STATUS for versions from 8.0.34 to 10.0).
	
PS Sorry for incorrect previous testing 
