### PR TITLE
Rework query EXPLAIN compatibility for modern MySQL

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -3,6 +3,7 @@ Changelog for innotop:
 2026-05-21: version 1.16.0
 	* Rework query EXPLAIN compatibility for modern MySQL.
 	* Add JSON and TREE EXPLAIN formats in query analysis.
+	* Add runtime EXPLAIN ANALYZE support in query analysis.
 	* Quote current database names during query analysis.
 
 2026-05-20: version 1.15.4

--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,10 @@
 Changelog for innotop:
 
+2026-05-21: version 1.16.0
+	* Rework query EXPLAIN compatibility for modern MySQL.
+	* Add JSON and TREE EXPLAIN formats in query analysis.
+	* Quote current database names during query analysis.
+
 2026-05-20: version 1.15.4
 	* Extend MySQL 9.x compatibility through the 9.x series.
 	* Keep replication status field normalization limited to fields used by built-in dashboards.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+innotop (1.16.0-1) unstable; urgency=medium
+
+  * New upstream version 1.16.0
+  * Rework query EXPLAIN compatibility for modern MySQL.
+  * Quote current database names during query analysis.
+
+ -- Innotop Developers <eslocombe@gmail.com>  Thu, 21 May 2026 12:00:00 +0200
+
 innotop (1.15.4-1) unstable; urgency=medium
 
   * New upstream version 1.15.4

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ innotop (1.16.0-1) unstable; urgency=medium
 
   * New upstream version 1.16.0
   * Rework query EXPLAIN compatibility for modern MySQL.
+  * Add runtime EXPLAIN ANALYZE support in query analysis.
   * Quote current database names during query analysis.
 
  -- Innotop Developers <eslocombe@gmail.com>  Thu, 21 May 2026 12:00:00 +0200

--- a/innotop
+++ b/innotop
@@ -6427,7 +6427,7 @@ sub explain_sql_for_optimized_query {
 sub explain_analyze_sql_for {
    my ( $dbh, $query ) = @_;
 
-   if ( explain_server_is_mariadb($dbh) ) {
+   if ( mysql_is_mariadb($dbh) ) {
       return unless version_ge($dbh, '10.1.0');
       return "ANALYZE\n" . $query;
    }
@@ -6485,19 +6485,13 @@ sub use_database_sql_for {
 # explain_uses_format_traditional {{{3
 sub explain_uses_format_traditional {
    my ( $dbh ) = @_;
-   return !explain_server_is_mariadb($dbh) && version_ge($dbh, '8.0.0');
+   return !mysql_is_mariadb($dbh) && version_ge($dbh, '8.0.0');
 }
 
 # explain_supports_tree {{{3
 sub explain_supports_tree {
    my ( $dbh ) = @_;
-   return !explain_server_is_mariadb($dbh) && version_ge($dbh, '8.0.16');
-}
-
-# explain_server_is_mariadb {{{3
-sub explain_server_is_mariadb {
-   my ( $dbh ) = @_;
-   return ($dbh->{mysql_serverinfo} || '') =~ m/mariadb/i;
+   return !mysql_is_mariadb($dbh) && version_ge($dbh, '8.0.16');
 }
 
 # sql_top_level_keywords {{{3

--- a/innotop
+++ b/innotop
@@ -6205,9 +6205,7 @@ sub display_explain {
       my $explain_query = explain_sql_for($meta->{dbh}, $query, 'TRADITIONAL');
 
       eval {
-         if ( $db ) {
-            do_query($cxn, "use $db");
-         }
+         use_query_database($cxn, $meta->{dbh}, $db);
          my $sth = do_query($cxn, $explain_query);
 
          my $res;
@@ -6229,7 +6227,9 @@ sub display_explain {
             '',
             "The query could not be explained.  Only SELECT queries and SELECT "
             . "parts of some INSERT, REPLACE, and CREATE TABLE queries can be "
-            . "explained.";
+            . "explained.",
+            '',
+            "Error: $EVAL_ERROR";
       }
 
    }
@@ -6277,9 +6277,7 @@ sub display_explain_text {
          push @display_lines, no_ctrl_char($explain_query);
 
          eval {
-            if ( $db ) {
-               do_query($cxn, "use $db");
-            }
+            use_query_database($cxn, $meta->{dbh}, $db);
             my $sth = do_query($cxn, $explain_query);
             my $res;
             while ( $res = $sth->fetchrow_hashref() ) {
@@ -6387,6 +6385,19 @@ sub explain_sql_for_optimized_query {
       if explain_uses_format_traditional($dbh);
 
    return "EXPLAIN EXTENDED\n" . $query;
+}
+
+# use_query_database {{{3
+sub use_query_database {
+   my ( $cxn, $dbh, $db ) = @_;
+   return unless defined $db && length $db;
+   return do_query($cxn, use_database_sql_for($dbh, $db));
+}
+
+# use_database_sql_for {{{3
+sub use_database_sql_for {
+   my ( $dbh, $db ) = @_;
+   return 'USE ' . $dbh->quote_identifier($db);
 }
 
 # explain_uses_format_traditional {{{3
@@ -6609,9 +6620,7 @@ sub show_optimized_query {
       push @display_lines, no_ctrl_char($info->{query});
 
       eval {
-         if ( $db ) {
-            do_query($cxn, "use $db");
-         }
+         use_query_database($cxn, $meta->{dbh}, $db);
          do_query( $cxn, explain_sql_for_optimized_query($meta->{dbh}, $query) )
             or die "Can't explain query";
          my $sth = do_query($cxn, 'SHOW WARNINGS');

--- a/innotop
+++ b/innotop
@@ -6257,6 +6257,50 @@ sub display_explain_tree {
    display_explain_text($info, 'TREE');
 }
 
+# display_explain_analyze {{{3
+sub display_explain_analyze {
+   my $info = shift;
+   my $cxn  = $info->{cxn};
+   my $db   = $info->{db};
+   my $meta = $dbhs{$cxn};
+
+   my ( $mods, $query ) = rewrite_for_explain($info->{query});
+   my @display_lines;
+
+   if ( $query ) {
+      my $analyze_query = explain_analyze_sql_for($meta->{dbh}, $query);
+
+      if ( !$analyze_query ) {
+         push @display_lines, '', 'EXPLAIN ANALYZE is not supported on this server.';
+      }
+      elsif ( !confirm_explain_analyze() ) {
+         push @display_lines, '', 'EXPLAIN ANALYZE cancelled.';
+      }
+      else {
+         push @display_lines, no_ctrl_char($analyze_query);
+
+         eval {
+            use_query_database($cxn, $meta->{dbh}, $db);
+            my $sth = do_query($cxn, $analyze_query);
+            push @display_lines, explain_text_result_lines($sth);
+         };
+
+         if ( $EVAL_ERROR ) {
+            push @display_lines, '', "EXPLAIN ANALYZE could not be generated: $EVAL_ERROR";
+         }
+      }
+   }
+   else {
+      push @display_lines, '', 'EXPLAIN ANALYZE could not be generated.';
+   }
+
+   if ( $mods ) {
+      push @display_lines, '', '[This query has been re-written to be explainable]';
+   }
+
+   draw_screen(\@display_lines, { raw => 1 } );
+}
+
 # display_explain_text {{{3
 sub display_explain_text {
    my ( $info, $format ) = @_;
@@ -6279,15 +6323,7 @@ sub display_explain_text {
          eval {
             use_query_database($cxn, $meta->{dbh}, $db);
             my $sth = do_query($cxn, $explain_query);
-            my $res;
-            while ( $res = $sth->fetchrow_hashref() ) {
-               if ( exists $res->{EXPLAIN} || exists $res->{explain} ) {
-                  push @display_lines, no_ctrl_char($res->{EXPLAIN} || $res->{explain});
-               }
-               else {
-                  push @display_lines, no_ctrl_char(join("\t", map { $res->{$_} || '' } sort keys %$res));
-               }
-            }
+            push @display_lines, explain_text_result_lines($sth);
          };
 
          if ( $EVAL_ERROR ) {
@@ -6385,6 +6421,52 @@ sub explain_sql_for_optimized_query {
       if explain_uses_format_traditional($dbh);
 
    return "EXPLAIN EXTENDED\n" . $query;
+}
+
+# explain_analyze_sql_for {{{3
+sub explain_analyze_sql_for {
+   my ( $dbh, $query ) = @_;
+
+   if ( explain_server_is_mariadb($dbh) ) {
+      return unless version_ge($dbh, '10.1.0');
+      return "ANALYZE\n" . $query;
+   }
+
+   return unless version_ge($dbh, '8.0.18');
+   return "EXPLAIN ANALYZE FORMAT=TREE\n" . $query
+      if version_ge($dbh, '8.0.21');
+   return "EXPLAIN ANALYZE\n" . $query;
+}
+
+# explain_text_result_lines {{{3
+sub explain_text_result_lines {
+   my ( $sth ) = @_;
+   my @columns = @{ $sth->{NAME_lc} || $sth->{NAME} || [] };
+   my @lines;
+
+   while ( my $res = $sth->fetchrow_hashref('NAME_lc') ) {
+      if ( exists $res->{EXPLAIN} || exists $res->{explain} ) {
+         my $text = exists $res->{EXPLAIN} ? $res->{EXPLAIN} : $res->{explain};
+         push @lines, no_ctrl_char($text);
+      }
+      elsif ( @columns ) {
+         unless ( @lines ) {
+            push @lines, no_ctrl_char(join("\t", @columns));
+         }
+         push @lines, no_ctrl_char(join("\t", map { defined $res->{$_} ? $res->{$_} : '' } @columns));
+      }
+      else {
+         push @lines, no_ctrl_char(join("\t", map { defined $res->{$_} ? $res->{$_} : '' } sort keys %$res));
+      }
+   }
+
+   return @lines;
+}
+
+# confirm_explain_analyze {{{3
+sub confirm_explain_analyze {
+   my $answer = pause('EXPLAIN ANALYZE executes the query. Continue? y/N ');
+   return $answer && $answer =~ m/y/i;
 }
 
 # use_query_database {{{3
@@ -10010,6 +10092,7 @@ sub analyze_query {
    return unless $info;
 
    my %actions = (
+      a => \&display_explain_analyze,
       e => \&display_explain,
       f => \&show_full_query,
       j => \&display_explain_json,
@@ -10019,7 +10102,7 @@ sub analyze_query {
    do {
       $actions{$action}->($info);
       print "\n";
-      $action = pause('Press e to explain, j for JSON, t for TREE, f for full query, o for optimized query');
+      $action = pause('Press e to explain, a to analyze, j for JSON, t for TREE, f for full query, o for optimized query');
    } while ( exists($actions{$action}) );
 }
 
@@ -10943,11 +11026,13 @@ innotop hides inactive processes and its own process.  You can toggle these on
 and off with the 'i' and 'a' keys.
 
 You can EXPLAIN a query from this mode with the 'e' key.  This displays the
-query's full text and the tabular results of EXPLAIN.  You can also use 'j' and
-'t' from the query analysis prompt to display EXPLAIN FORMAT=JSON and EXPLAIN
-FORMAT=TREE where the server supports them, and 'o' to display optimizer rewrite
-notes.  innotop also tries to rewrite certain queries to make them EXPLAIN-able.
-For example, INSERT/SELECT statements are rewritable.
+query's full text and the tabular results of EXPLAIN.  You can also use 'a' to
+run EXPLAIN ANALYZE where the server supports it, 'j' and 't' from the query
+analysis prompt to display EXPLAIN FORMAT=JSON and EXPLAIN FORMAT=TREE, and 'o'
+to display optimizer rewrite notes.  EXPLAIN ANALYZE executes the query, so
+innotop asks for confirmation before running it.  innotop also tries to rewrite
+certain queries to make them EXPLAIN-able.  For example, INSERT/SELECT
+statements are rewritable.
 
 This mode displays the L<"q_header"> and L<"processlist"> tables by default.
 

--- a/innotop
+++ b/innotop
@@ -6194,6 +6194,7 @@ sub display_explain {
    my $info = shift;
    my $cxn   = $info->{cxn};
    my $db    = $info->{db};
+   my $meta  = $dbhs{$cxn};
 
    my ( $mods, $query ) = rewrite_for_explain($info->{query});
 
@@ -6201,14 +6202,13 @@ sub display_explain {
 
    if ( $query ) {
 
-      my $part = version_ge($dbhs{$cxn}->{dbh}, '5.1.5') && ($dbhs{$cxn}->{dbh}->{mysql_serverinfo} !~ /^8\.0\./) ? 'PARTITIONS' : '';
-      $query = "EXPLAIN $part\n" . $query;
+      my $explain_query = explain_sql_for($meta->{dbh}, $query, 'TRADITIONAL');
 
       eval {
          if ( $db ) {
             do_query($cxn, "use $db");
          }
-         my $sth = do_query($cxn, $query);
+         my $sth = do_query($cxn, $explain_query);
 
          my $res;
          while ( $res = $sth->fetchrow_hashref() ) {
@@ -6222,12 +6222,14 @@ sub display_explain {
          }
       };
 
+      $query = $explain_query;
+
       if ( $EVAL_ERROR ) {
          push @display_lines,
             '',
-            "The query could not be explained.  Only SELECT queries can be "
-            . "explained; innotop tries to rewrite certain REPLACE and INSERT queries "
-            . "into SELECT, but this doesn't always succeed.";
+            "The query could not be explained.  Only SELECT queries and SELECT "
+            . "parts of some INSERT, REPLACE, and CREATE TABLE queries can be "
+            . "explained.";
       }
 
    }
@@ -6243,18 +6245,349 @@ sub display_explain {
    draw_screen(\@display_lines, { raw => 1 } );
 }
 
+# display_explain_json {{{3
+sub display_explain_json {
+   my $info = shift;
+   display_explain_text($info, 'JSON');
+}
+
+# display_explain_tree {{{3
+sub display_explain_tree {
+   my $info = shift;
+   display_explain_text($info, 'TREE');
+}
+
+# display_explain_text {{{3
+sub display_explain_text {
+   my ( $info, $format ) = @_;
+   my $cxn  = $info->{cxn};
+   my $db   = $info->{db};
+   my $meta = $dbhs{$cxn};
+
+   my ( $mods, $query ) = rewrite_for_explain($info->{query});
+   my @display_lines;
+
+   if ( $query ) {
+      my $explain_query = explain_sql_for($meta->{dbh}, $query, $format);
+
+      if ( !$explain_query ) {
+         push @display_lines, '', "EXPLAIN FORMAT=$format is not supported on this server.";
+      }
+      else {
+         push @display_lines, no_ctrl_char($explain_query);
+
+         eval {
+            if ( $db ) {
+               do_query($cxn, "use $db");
+            }
+            my $sth = do_query($cxn, $explain_query);
+            my $res;
+            while ( $res = $sth->fetchrow_hashref() ) {
+               if ( exists $res->{EXPLAIN} || exists $res->{explain} ) {
+                  push @display_lines, no_ctrl_char($res->{EXPLAIN} || $res->{explain});
+               }
+               else {
+                  push @display_lines, no_ctrl_char(join("\t", map { $res->{$_} || '' } sort keys %$res));
+               }
+            }
+         };
+
+         if ( $EVAL_ERROR ) {
+            push @display_lines, '', "EXPLAIN FORMAT=$format could not be generated: $EVAL_ERROR";
+         }
+      }
+   }
+   else {
+      push @display_lines, '', "EXPLAIN FORMAT=$format could not be generated.";
+   }
+
+   if ( $mods ) {
+      push @display_lines, '', '[This query has been re-written to be explainable]';
+   }
+
+   draw_screen(\@display_lines, { raw => 1 } );
+}
+
 # rewrite_for_explain {{{3
 sub rewrite_for_explain {
    my $query = shift;
 
-   my $mods = 0;
-   my $orig = $query;
-   $mods += $query =~ s/^\s*(?:replace|insert).*?select/select/is;
-   $mods += $query =~ s/^
-      \s*create\s+(?:temporary\s+)?table
-      \s+(?:\S+\s+)as\s+select/select/xis;
-   $mods += $query =~ s/\s+on\s+duplicate\s+key\s+update.*$//is;
-   return ( $mods, $query );
+   return ( 0, undef ) unless defined $query;
+
+   my @tokens = sql_top_level_keywords($query);
+   return ( 0, undef ) unless @tokens;
+
+   my $first = lc($tokens[0]->{word});
+
+   if ( $first eq 'select' ) {
+      return ( 0, $query );
+   }
+
+   if ( $first eq 'with' ) {
+      return ( 0, $query ) if sql_with_main_statement_is_select(\@tokens, 0);
+      return ( 0, undef );
+   }
+
+   if ( $first eq 'insert' || $first eq 'replace' ) {
+      my $select_pos = sql_select_part_pos(\@tokens, 1);
+      if ( defined $select_pos ) {
+         my $rewritten = substr($query, $select_pos);
+         $rewritten = strip_on_duplicate_key_update($rewritten);
+         return ( 1, $rewritten );
+      }
+      return ( 0, undef );
+   }
+
+   if ( $first eq 'create' ) {
+      my $select_pos = sql_create_select_part_pos(\@tokens);
+      if ( defined $select_pos ) {
+         return ( 1, substr($query, $select_pos) );
+      }
+      return ( 0, undef );
+   }
+
+   return ( 0, undef );
+}
+
+# explain_sql_for {{{3
+sub explain_sql_for {
+   my ( $dbh, $query, $format ) = @_;
+   $format ||= 'TRADITIONAL';
+
+   if ( $format eq 'TRADITIONAL' ) {
+      return explain_traditional_sql_for($dbh, $query);
+   }
+   elsif ( $format eq 'JSON' ) {
+      return "EXPLAIN FORMAT=JSON\n" . $query;
+   }
+   elsif ( $format eq 'TREE' ) {
+      return unless explain_supports_tree($dbh);
+      return "EXPLAIN FORMAT=TREE\n" . $query;
+   }
+
+   return;
+}
+
+# explain_traditional_sql_for {{{3
+sub explain_traditional_sql_for {
+   my ( $dbh, $query ) = @_;
+
+   return "EXPLAIN FORMAT=TRADITIONAL\n" . $query
+      if explain_uses_format_traditional($dbh);
+
+   my $part = version_ge($dbh, '5.1.5') ? ' PARTITIONS' : '';
+   return "EXPLAIN$part\n" . $query;
+}
+
+# explain_sql_for_optimized_query {{{3
+sub explain_sql_for_optimized_query {
+   my ( $dbh, $query ) = @_;
+
+   return explain_traditional_sql_for($dbh, $query)
+      if explain_uses_format_traditional($dbh);
+
+   return "EXPLAIN EXTENDED\n" . $query;
+}
+
+# explain_uses_format_traditional {{{3
+sub explain_uses_format_traditional {
+   my ( $dbh ) = @_;
+   return !explain_server_is_mariadb($dbh) && version_ge($dbh, '8.0.0');
+}
+
+# explain_supports_tree {{{3
+sub explain_supports_tree {
+   my ( $dbh ) = @_;
+   return !explain_server_is_mariadb($dbh) && version_ge($dbh, '8.0.16');
+}
+
+# explain_server_is_mariadb {{{3
+sub explain_server_is_mariadb {
+   my ( $dbh ) = @_;
+   return ($dbh->{mysql_serverinfo} || '') =~ m/mariadb/i;
+}
+
+# sql_top_level_keywords {{{3
+sub sql_top_level_keywords {
+   my ( $query ) = @_;
+   my @tokens;
+   my $len   = length($query);
+   my $depth = 0;
+   my $i     = 0;
+
+   while ( $i < $len ) {
+      my $ch = substr($query, $i, 1);
+      my $next = $i + 1 < $len ? substr($query, $i + 1, 1) : '';
+
+      if ( $ch =~ m/\s/ ) {
+         $i++;
+      }
+      elsif ( $ch eq "'" || $ch eq '"' ) {
+         $i = sql_skip_quoted_string($query, $i, $ch);
+      }
+      elsif ( $ch eq '`' ) {
+         $i = sql_skip_quoted_identifier($query, $i);
+      }
+      elsif ( $ch eq '#' ) {
+         $i = sql_skip_line_comment($query, $i);
+      }
+      elsif ( $ch eq '-' && $next eq '-' && sql_dash_dash_starts_comment($query, $i) ) {
+         $i = sql_skip_line_comment($query, $i + 2);
+      }
+      elsif ( $ch eq '/' && $next eq '*' ) {
+         $i = sql_skip_block_comment($query, $i);
+      }
+      elsif ( $ch eq '(' ) {
+         $depth++;
+         $i++;
+      }
+      elsif ( $ch eq ')' ) {
+         $depth-- if $depth > 0;
+         $i++;
+      }
+      elsif ( $depth == 0 && $ch =~ m/[A-Za-z_]/ ) {
+         my $start = $i;
+         $i++ while $i < $len && substr($query, $i, 1) =~ m/[A-Za-z0-9_\$]/;
+         push @tokens, { word => substr($query, $start, $i - $start), pos => $start };
+      }
+      else {
+         $i++;
+      }
+   }
+
+   return @tokens;
+}
+
+# sql_skip_quoted_string {{{3
+sub sql_skip_quoted_string {
+   my ( $query, $pos, $quote ) = @_;
+   my $len = length($query);
+   my $i   = $pos + 1;
+
+   while ( $i < $len ) {
+      my $ch = substr($query, $i, 1);
+      my $next = $i + 1 < $len ? substr($query, $i + 1, 1) : '';
+
+      if ( $ch eq '\\' ) {
+         $i += 2;
+      }
+      elsif ( $ch eq $quote && $next eq $quote ) {
+         $i += 2;
+      }
+      elsif ( $ch eq $quote ) {
+         return $i + 1;
+      }
+      else {
+         $i++;
+      }
+   }
+
+   return $len;
+}
+
+# sql_skip_quoted_identifier {{{3
+sub sql_skip_quoted_identifier {
+   my ( $query, $pos ) = @_;
+   my $len = length($query);
+   my $i   = $pos + 1;
+
+   while ( $i < $len ) {
+      my $ch = substr($query, $i, 1);
+      my $next = $i + 1 < $len ? substr($query, $i + 1, 1) : '';
+      if ( $ch eq '`' && $next eq '`' ) {
+         $i += 2;
+      }
+      elsif ( $ch eq '`' ) {
+         return $i + 1;
+      }
+      else {
+         $i++;
+      }
+   }
+
+   return $len;
+}
+
+# sql_dash_dash_starts_comment {{{3
+sub sql_dash_dash_starts_comment {
+   my ( $query, $pos ) = @_;
+   return 0 unless $pos + 2 >= length($query) || substr($query, $pos + 2, 1) =~ m/\s/;
+   return 1;
+}
+
+# sql_skip_line_comment {{{3
+sub sql_skip_line_comment {
+   my ( $query, $pos ) = @_;
+   my $len = length($query);
+   my $i   = $pos;
+   $i++ while $i < $len && substr($query, $i, 1) ne "\n";
+   return $i;
+}
+
+# sql_skip_block_comment {{{3
+sub sql_skip_block_comment {
+   my ( $query, $pos ) = @_;
+   my $end = index($query, '*/', $pos + 2);
+   return $end >= 0 ? $end + 2 : length($query);
+}
+
+# sql_with_main_statement_is_select {{{3
+sub sql_with_main_statement_is_select {
+   my ( $tokens, $with_idx ) = @_;
+
+   for my $i ( $with_idx + 1 .. $#$tokens ) {
+      my $word = lc($tokens->[$i]->{word});
+      return $word eq 'select' if $word =~ m/^(?:select|insert|replace|update|delete|table)$/;
+   }
+
+   return 0;
+}
+
+# sql_select_part_pos {{{3
+sub sql_select_part_pos {
+   my ( $tokens, $start_idx ) = @_;
+
+   for my $i ( $start_idx .. $#$tokens ) {
+      my $word = lc($tokens->[$i]->{word});
+      return $tokens->[$i]->{pos} if $word eq 'select';
+      return $tokens->[$i]->{pos}
+         if $word eq 'with' && sql_with_main_statement_is_select($tokens, $i);
+   }
+
+   return;
+}
+
+# sql_create_select_part_pos {{{3
+sub sql_create_select_part_pos {
+   my ( $tokens ) = @_;
+
+   for my $i ( 1 .. $#$tokens - 1 ) {
+      next unless lc($tokens->[$i]->{word}) eq 'as';
+      my $next = lc($tokens->[$i + 1]->{word});
+      return $tokens->[$i + 1]->{pos} if $next eq 'select';
+      return $tokens->[$i + 1]->{pos}
+         if $next eq 'with' && sql_with_main_statement_is_select($tokens, $i + 1);
+   }
+
+   return;
+}
+
+# strip_on_duplicate_key_update {{{3
+sub strip_on_duplicate_key_update {
+   my ( $query ) = @_;
+   my @tokens = sql_top_level_keywords($query);
+
+   for my $i ( 0 .. $#tokens - 3 ) {
+      next unless lc($tokens[$i]->{word})     eq 'on';
+      next unless lc($tokens[$i + 1]->{word}) eq 'duplicate';
+      next unless lc($tokens[$i + 2]->{word}) eq 'key';
+      next unless lc($tokens[$i + 3]->{word}) eq 'update';
+      my $stripped = substr($query, 0, $tokens[$i]->{pos});
+      $stripped =~ s/\s+\z//;
+      return $stripped;
+   }
+
+   return $query;
 }
 
 # show_optimized_query {{{3
@@ -6279,7 +6612,8 @@ sub show_optimized_query {
          if ( $db ) {
             do_query($cxn, "use $db");
          }
-         do_query( $cxn, 'EXPLAIN EXTENDED ' . $query ) or die "Can't explain query";
+         do_query( $cxn, explain_sql_for_optimized_query($meta->{dbh}, $query) )
+            or die "Can't explain query";
          my $sth = do_query($cxn, 'SHOW WARNINGS');
          my $res = $sth->fetchall_arrayref({});
 
@@ -9669,12 +10003,14 @@ sub analyze_query {
    my %actions = (
       e => \&display_explain,
       f => \&show_full_query,
+      j => \&display_explain_json,
       o => \&show_optimized_query,
+      t => \&display_explain_tree,
    );
    do {
       $actions{$action}->($info);
       print "\n";
-      $action = pause('Press e to explain, f for full query, o for optimized query');
+      $action = pause('Press e to explain, j for JSON, t for TREE, f for full query, o for optimized query');
    } while ( exists($actions{$action}) );
 }
 
@@ -10598,10 +10934,11 @@ innotop hides inactive processes and its own process.  You can toggle these on
 and off with the 'i' and 'a' keys.
 
 You can EXPLAIN a query from this mode with the 'e' key.  This displays the
-query's full text, the results of EXPLAIN, and in newer MySQL versions, even
-the optimized query resulting from EXPLAIN EXTENDED.  innotop also tries to
-rewrite certain queries to make them EXPLAIN-able.  For example, INSERT/SELECT
-statements are rewritable.
+query's full text and the tabular results of EXPLAIN.  You can also use 'j' and
+'t' from the query analysis prompt to display EXPLAIN FORMAT=JSON and EXPLAIN
+FORMAT=TREE where the server supports them, and 'o' to display optimizer rewrite
+notes.  innotop also tries to rewrite certain queries to make them EXPLAIN-able.
+For example, INSERT/SELECT statements are rewritable.
 
 This mode displays the L<"q_header"> and L<"processlist"> tables by default.
 

--- a/innotop
+++ b/innotop
@@ -22,7 +22,7 @@
 use strict;
 use warnings FATAL => 'all';
 
-our $VERSION = '1.15.4';
+our $VERSION = '1.16.0';
 
 # Find the home directory; it's different on different OSes.
 our $homepath = $ENV{HOME} || $ENV{HOMEPATH} || $ENV{USERPROFILE} || '.';

--- a/innotop.spec
+++ b/innotop.spec
@@ -3,7 +3,7 @@
 #
 Name:      innotop
 Summary:   A MySQL and InnoDB monitor program.
-Version:   1.15.4
+Version:   1.16.0
 Release:   1%{?dist}
 Vendor:    Baron Schwartz <baron@percona.com>
 Packager:  Frederic Descamps <lefred@percona.com>
@@ -122,6 +122,10 @@ find %{buildroot}%{_prefix}             \
 %defattr(-,root,root)
 
 %changelog
+* Thu May 21 2026 Innotop Developers <eslocombe@gmail.com> - 1.16.0-1
+ - Rework query EXPLAIN compatibility for modern MySQL
+ - Quote database names during query analysis
+
 * Wed May 20 2026 Innotop Developers <eslocombe@gmail.com> - 1.15.4-1
  - Extend MySQL 9.x compatibility
 

--- a/innotop.spec
+++ b/innotop.spec
@@ -124,6 +124,7 @@ find %{buildroot}%{_prefix}             \
 %changelog
 * Thu May 21 2026 Innotop Developers <eslocombe@gmail.com> - 1.16.0-1
  - Rework query EXPLAIN compatibility for modern MySQL
+ - Add runtime EXPLAIN ANALYZE support in query analysis
  - Quote database names during query analysis
 
 * Wed May 20 2026 Innotop Developers <eslocombe@gmail.com> - 1.15.4-1

--- a/t/Explain.t
+++ b/t/Explain.t
@@ -27,6 +27,19 @@ require "innotop";
    }
 }
 
+{
+   package TestSTH;
+   sub new {
+      my ( $class, $columns, $rows ) = @_;
+      return bless { NAME_lc => $columns, rows => $rows, pos => 0 }, $class;
+   }
+   sub fetchrow_hashref {
+      my ( $self ) = @_;
+      return if $self->{pos} >= @{ $self->{rows} };
+      return $self->{rows}->[ $self->{pos}++ ];
+   }
+}
+
 sub dbh_for {
    my ( $version ) = @_;
    return TestDBH->new($version);
@@ -203,6 +216,52 @@ ok(
    'MariaDB does not use TREE EXPLAIN',
 );
 
+ok(
+   !defined explain_analyze_sql_for(dbh_for('8.0.17'), 'SELECT 1'),
+   'MySQL before 8.0.18 does not use EXPLAIN ANALYZE',
+);
+
+is(
+   explain_analyze_sql_for(dbh_for('8.0.18'), 'SELECT 1'),
+   "EXPLAIN ANALYZE\nSELECT 1",
+   'MySQL 8.0.18 uses EXPLAIN ANALYZE',
+);
+
+is(
+   explain_analyze_sql_for(dbh_for('8.0.21'), 'SELECT 1'),
+   "EXPLAIN ANALYZE FORMAT=TREE\nSELECT 1",
+   'MySQL 8.0.21 uses EXPLAIN ANALYZE FORMAT=TREE',
+);
+
+is(
+   explain_analyze_sql_for(dbh_for('8.0.45'), 'SELECT 1'),
+   "EXPLAIN ANALYZE FORMAT=TREE\nSELECT 1",
+   'MySQL 8.0.45 uses EXPLAIN ANALYZE FORMAT=TREE',
+);
+
+is(
+   explain_analyze_sql_for(dbh_for('9.7.0'), 'SELECT 1'),
+   "EXPLAIN ANALYZE FORMAT=TREE\nSELECT 1",
+   'MySQL 9.7 uses EXPLAIN ANALYZE FORMAT=TREE',
+);
+
+ok(
+   !defined explain_analyze_sql_for(dbh_for('10.0.38-MariaDB'), 'SELECT 1'),
+   'MariaDB before 10.1 does not use ANALYZE statement',
+);
+
+is(
+   explain_analyze_sql_for(dbh_for('10.1.48-MariaDB'), 'SELECT 1'),
+   "ANALYZE\nSELECT 1",
+   'MariaDB 10.1 uses ANALYZE statement',
+);
+
+is(
+   explain_analyze_sql_for(dbh_for('10.11.0-MariaDB'), 'SELECT 1'),
+   "ANALYZE\nSELECT 1",
+   'MariaDB 10.11 uses ANALYZE statement',
+);
+
 is(
    explain_sql_for_optimized_query(dbh_for('9.7.0'), 'SELECT 1'),
    "EXPLAIN FORMAT=TRADITIONAL\nSELECT 1",
@@ -259,5 +318,37 @@ is_deeply(
    [ [ 'test-cxn', 'USE `qa-01_schema`' ] ],
    'use_query_database executes quoted USE statement',
 );
+
+is_deeply(
+   [ explain_text_result_lines(TestSTH->new([ 'explain' ], [ { explain => '-> scan' } ])) ],
+   [ '-> scan' ],
+   'single EXPLAIN column is displayed directly',
+);
+
+is_deeply(
+   [
+      explain_text_result_lines(TestSTH->new(
+         [ qw(id select_type table r_rows) ],
+         [ { id => 1, select_type => 'SIMPLE', table => 't1', r_rows => 10 } ],
+      )),
+   ],
+   [
+      "id\tselect_type\ttable\tr_rows",
+      "1\tSIMPLE\tt1\t10",
+   ],
+   'multi-column ANALYZE result preserves DBI column order',
+);
+
+{
+   no warnings qw(once redefine);
+   local *pause = sub { return 'y' };
+   ok(confirm_explain_analyze(), 'EXPLAIN ANALYZE confirmation accepts y');
+}
+
+{
+   no warnings qw(once redefine);
+   local *pause = sub { return 'n' };
+   ok(!confirm_explain_analyze(), 'EXPLAIN ANALYZE confirmation rejects non-y');
+}
 
 done_testing();

--- a/t/Explain.t
+++ b/t/Explain.t
@@ -14,9 +14,22 @@ BEGIN {
 
 require "innotop";
 
+{
+   package TestDBH;
+   sub new {
+      my ( $class, $version ) = @_;
+      return bless { mysql_serverinfo => $version }, $class;
+   }
+   sub quote_identifier {
+      my ( undef, $identifier ) = @_;
+      $identifier =~ s/`/``/g;
+      return "`$identifier`";
+   }
+}
+
 sub dbh_for {
    my ( $version ) = @_;
-   return { mysql_serverinfo => $version };
+   return TestDBH->new($version);
 }
 
 sub rewrite_is {
@@ -206,6 +219,45 @@ is(
    explain_sql_for_optimized_query(dbh_for('10.11.0-MariaDB'), 'SELECT 1'),
    "EXPLAIN EXTENDED\nSELECT 1",
    'MariaDB optimized query keeps EXPLAIN EXTENDED',
+);
+
+my %use_sql_for = (
+   '0'                 => 'USE `0`',
+   '123_schema'        => 'USE `123_schema`',
+   'dash-name_test'    => 'USE `dash-name_test`',
+   'qa-01_schema'      => 'USE `qa-01_schema`',
+   'select'            => 'USE `select`',
+   'schema with space' => 'USE `schema with space`',
+   'schema`tick'       => 'USE `schema``tick`',
+);
+
+foreach my $db ( sort keys %use_sql_for ) {
+   is(
+      use_database_sql_for(dbh_for('8.0.45'), $db),
+      $use_sql_for{$db},
+      "USE quotes synthetic database name $db",
+   );
+}
+
+my @do_query_calls;
+{
+   no warnings qw(once redefine);
+   local *do_query = sub {
+      push @do_query_calls, [ @_ ];
+      return 'used';
+   };
+
+   is(
+      use_query_database('test-cxn', dbh_for('8.0.45'), 'qa-01_schema'),
+      'used',
+      'use_query_database returns do_query result',
+   );
+}
+
+is_deeply(
+   \@do_query_calls,
+   [ [ 'test-cxn', 'USE `qa-01_schema`' ] ],
+   'use_query_database executes quoted USE statement',
 );
 
 done_testing();

--- a/t/Explain.t
+++ b/t/Explain.t
@@ -1,0 +1,211 @@
+#!/usr/bin/perl
+use strict;
+use warnings FATAL => 'all';
+use Test::More;
+
+my $path;
+BEGIN {
+   my $pwd = `pwd`;
+   chomp $pwd;
+   $path = "$pwd/$0";
+   $path =~ s{/[^/]+/[^/]+$}{/};
+   unshift @INC, $path;
+};
+
+require "innotop";
+
+sub dbh_for {
+   my ( $version ) = @_;
+   return { mysql_serverinfo => $version };
+}
+
+sub rewrite_is {
+   my ( $sql, $want_mods, $want_query, $name ) = @_;
+   my ( $got_mods, $got_query ) = rewrite_for_explain($sql);
+   is( $got_mods ? 1 : 0, $want_mods ? 1 : 0, "$name modifies flag" );
+   is( $got_query, $want_query, "$name rewritten query" );
+}
+
+sub rewrite_is_undef {
+   my ( $sql, $name ) = @_;
+   my ( $got_mods, $got_query ) = rewrite_for_explain($sql);
+   is( $got_mods ? 1 : 0, 0, "$name modifies flag" );
+   ok( !defined $got_query, "$name is not explainable" );
+}
+
+rewrite_is(
+   'SELECT 1',
+   0,
+   'SELECT 1',
+   'plain SELECT',
+);
+
+rewrite_is(
+   'WITH c AS (SELECT 1) SELECT * FROM c',
+   0,
+   'WITH c AS (SELECT 1) SELECT * FROM c',
+   'WITH SELECT',
+);
+
+rewrite_is(
+   'INSERT INTO dst SELECT * FROM src',
+   1,
+   'SELECT * FROM src',
+   'INSERT SELECT',
+);
+
+rewrite_is(
+   'REPLACE INTO dst SELECT * FROM src',
+   1,
+   'SELECT * FROM src',
+   'REPLACE SELECT',
+);
+
+rewrite_is(
+   'INSERT INTO dst WITH c AS (SELECT 1) SELECT * FROM c',
+   1,
+   'WITH c AS (SELECT 1) SELECT * FROM c',
+   'INSERT WITH SELECT',
+);
+
+rewrite_is(
+   'CREATE TEMPORARY TABLE dst AS SELECT * FROM src',
+   1,
+   'SELECT * FROM src',
+   'CREATE TEMPORARY TABLE AS SELECT',
+);
+
+rewrite_is(
+   'CREATE TABLE dst (id int) AS WITH c AS (SELECT 1) SELECT * FROM c',
+   1,
+   'WITH c AS (SELECT 1) SELECT * FROM c',
+   'CREATE TABLE AS WITH SELECT',
+);
+
+rewrite_is(
+   "INSERT INTO dst SELECT 'on duplicate key update' AS txt FROM src ON DUPLICATE KEY UPDATE txt = VALUES(txt)",
+   1,
+   "SELECT 'on duplicate key update' AS txt FROM src",
+   'INSERT SELECT strips ON DUPLICATE KEY UPDATE',
+);
+
+rewrite_is(
+   'SELECT `from` FROM src WHERE txt = "INSERT INTO x SELECT y"',
+   0,
+   'SELECT `from` FROM src WHERE txt = "INSERT INTO x SELECT y"',
+   'quoted strings and identifiers in SELECT',
+);
+
+rewrite_is_undef(
+   "INSERT INTO dst VALUES ('SELECT 1')",
+   'INSERT VALUES',
+);
+
+rewrite_is_undef(
+   'INSERT INTO my$select VALUES (1)',
+   'identifier containing select',
+);
+
+rewrite_is_undef(
+   'UPDATE dst SET a = (SELECT 1)',
+   'UPDATE with subquery',
+);
+
+rewrite_is_undef(
+   'DELETE FROM dst WHERE id IN (SELECT id FROM src)',
+   'DELETE with subquery',
+);
+
+rewrite_is_undef(
+   'WITH c AS (SELECT 1) UPDATE dst SET a = 1',
+   'WITH UPDATE',
+);
+
+rewrite_is_undef(
+   "/* SELECT 1 */ INSERT INTO dst VALUES ('SELECT 1')",
+   'comments are ignored',
+);
+
+is(
+   explain_sql_for(dbh_for('5.0.96'), 'SELECT 1', 'TRADITIONAL'),
+   "EXPLAIN\nSELECT 1",
+   'MySQL 5.0 uses plain EXPLAIN',
+);
+
+is(
+   explain_sql_for(dbh_for('5.7.44'), 'SELECT 1', 'TRADITIONAL'),
+   "EXPLAIN PARTITIONS\nSELECT 1",
+   'MySQL 5.7 keeps EXPLAIN PARTITIONS',
+);
+
+is(
+   explain_sql_for(dbh_for('8.0.36'), 'SELECT 1', 'TRADITIONAL'),
+   "EXPLAIN FORMAT=TRADITIONAL\nSELECT 1",
+   'MySQL 8.0 uses FORMAT=TRADITIONAL',
+);
+
+is(
+   explain_sql_for(dbh_for('8.4.0'), 'SELECT 1', 'TRADITIONAL'),
+   "EXPLAIN FORMAT=TRADITIONAL\nSELECT 1",
+   'MySQL 8.4 uses FORMAT=TRADITIONAL',
+);
+
+is(
+   explain_sql_for(dbh_for('9.7.0'), 'SELECT 1', 'TRADITIONAL'),
+   "EXPLAIN FORMAT=TRADITIONAL\nSELECT 1",
+   'MySQL 9.7 uses FORMAT=TRADITIONAL',
+);
+
+is(
+   explain_sql_for(dbh_for('10.11.0-MariaDB'), 'SELECT 1', 'TRADITIONAL'),
+   "EXPLAIN PARTITIONS\nSELECT 1",
+   'MariaDB keeps EXPLAIN PARTITIONS',
+);
+
+is(
+   explain_sql_for(dbh_for('9.7.0'), 'SELECT 1', 'JSON'),
+   "EXPLAIN FORMAT=JSON\nSELECT 1",
+   'MySQL 9.7 JSON EXPLAIN',
+);
+
+is(
+   explain_sql_for(dbh_for('10.11.0-MariaDB'), 'SELECT 1', 'JSON'),
+   "EXPLAIN FORMAT=JSON\nSELECT 1",
+   'MariaDB JSON EXPLAIN',
+);
+
+is(
+   explain_sql_for(dbh_for('9.7.0'), 'SELECT 1', 'TREE'),
+   "EXPLAIN FORMAT=TREE\nSELECT 1",
+   'MySQL 9.7 TREE EXPLAIN',
+);
+
+ok(
+   !defined explain_sql_for(dbh_for('8.0.15'), 'SELECT 1', 'TREE'),
+   'MySQL before 8.0.16 does not use TREE EXPLAIN',
+);
+
+ok(
+   !defined explain_sql_for(dbh_for('10.11.0-MariaDB'), 'SELECT 1', 'TREE'),
+   'MariaDB does not use TREE EXPLAIN',
+);
+
+is(
+   explain_sql_for_optimized_query(dbh_for('9.7.0'), 'SELECT 1'),
+   "EXPLAIN FORMAT=TRADITIONAL\nSELECT 1",
+   'MySQL 9.7 optimized query uses FORMAT=TRADITIONAL',
+);
+
+is(
+   explain_sql_for_optimized_query(dbh_for('5.7.44'), 'SELECT 1'),
+   "EXPLAIN EXTENDED\nSELECT 1",
+   'MySQL 5.7 optimized query keeps EXPLAIN EXTENDED',
+);
+
+is(
+   explain_sql_for_optimized_query(dbh_for('10.11.0-MariaDB'), 'SELECT 1'),
+   "EXPLAIN EXTENDED\nSELECT 1",
+   'MariaDB optimized query keeps EXPLAIN EXTENDED',
+);
+
+done_testing();


### PR DESCRIPTION
## Summary

  Reworks query analysis EXPLAIN handling for modern MySQL while keeping legacy MySQL and MariaDB behavior intact.

  ## Changes

  - Use `EXPLAIN FORMAT=TRADITIONAL` on MySQL 8+/9+ instead of legacy `EXPLAIN PARTITIONS`.
  - Add query analysis actions for `EXPLAIN FORMAT=JSON` and `EXPLAIN FORMAT=TREE`.
  - Add runtime `EXPLAIN ANALYZE` support:
    - MySQL 8.0.18-8.0.20: `EXPLAIN ANALYZE`
    - MySQL 8.0.21+/9.x: `EXPLAIN ANALYZE FORMAT=TREE`
    - MariaDB 10.1+: `ANALYZE`
  - Ask for confirmation before running `EXPLAIN ANALYZE`, because it executes the query.
  - Quote current database names before query analysis, including names with dashes or other special characters.
  - Keep EXPLAIN rewriting limited to SELECT queries and SELECT parts of supported statements.

  ## Root Cause

  Modern MySQL syntax support diverges from the older `EXPLAIN PARTITIONS` / `EXPLAIN EXTENDED` path. Query analysis also used unquoted database names, so schemas with special characters could make EXPLAIN and optimizer output fail before the target query was analyzed.

  ## Validation

  - `perl -c innotop`
  - `prove t/*.t`
  - `git diff --check`
  - Tested on MySQL 9.7.0 and 8.0.45.
  - Live checked MySQL 9.7.0 with traditional, JSON, TREE, and ANALYZE EXPLAIN formats.
  - Live checked quoted `USE` with a synthetic dashed database name.

  ## Notes

  PR #222 also updates version/changelog entries for 1.15.4.