### PR TITLE
Keep raw query text for EXPLAIN actions

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,8 @@
 Changelog for innotop:
 
+2026-06-05: version 1.16.1
+	* Keep raw query text for EXPLAIN actions when display sanitization replaces literals.
+
 2026-05-21: version 1.16.0
 	* Rework query EXPLAIN compatibility for modern MySQL.
 	* Add JSON and TREE EXPLAIN formats in query analysis.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+innotop (1.16.1-1) unstable; urgency=medium
+
+  * New upstream version 1.16.1
+  * Keep raw query text for EXPLAIN actions when display sanitization replaces
+    literals.
+
+ -- Innotop Developers <eslocombe@gmail.com>  Fri, 05 Jun 2026 12:00:00 +0200
+
 innotop (1.16.0-1) unstable; urgency=medium
 
   * New upstream version 1.16.0

--- a/innotop
+++ b/innotop
@@ -22,7 +22,7 @@
 use strict;
 use warnings FATAL => 'all';
 
-our $VERSION = '1.16.0';
+our $VERSION = '1.16.1';
 
 # Find the home directory; it's different on different OSes.
 our $homepath = $ENV{HOME} || $ENV{HOMEPATH} || $ENV{USERPROFILE} || '.';
@@ -5850,6 +5850,9 @@ sub display_Q {
    # Get the data
    my @cxns             = get_connections();
    my @full_processlist = get_full_processlist(@cxns);
+   my %raw_query_for    = map {
+      query_analysis_key($_->{cxn}, $_->{id}) => $_->{info}
+   } grep { defined $_->{info} } @full_processlist;
 
    # Create header
    if ( $wanted{q_header} ) {
@@ -5892,6 +5895,12 @@ sub display_Q {
       my %hash;
       @hash{ qw(cxn id db query time user host) }
          = @{$_}{ qw(cxn mysql_thread_id db info time user hostname) };
+      $hash{query} = query_analysis_query_from(
+         \%raw_query_for,
+         $hash{cxn},
+         $hash{id},
+         $hash{query},
+      );
       # time is in seconds-to-time format; convert into something
       # ascii-sortable.
       $hash{time} = sprintf('%012s', $hash{time} =~ m/^([^.]*)/);
@@ -5968,6 +5977,7 @@ sub display_T {
 
    my @t_header;
    my @innodb_transactions;
+   my %raw_query_for;
    my %rows_for = (
       t_header            => \@t_header,
       innodb_transactions => \@innodb_transactions,
@@ -6004,6 +6014,9 @@ sub display_T {
             my $pre_txn = $pre_txns{$thd_id} || $cur_txn;
             my $hash    = extract_values($cur_txn, $cur_txn, $pre_txn, 'innodb_transactions');
             $hash->{cxn} = $cxn;
+            $raw_query_for{query_analysis_key($cxn, $hash->{mysql_thread_id})}
+               = $cur_txn->{query_text}
+               if defined $cur_txn->{query_text};
             push @innodb_transactions, $hash;
          }
       }
@@ -6024,6 +6037,12 @@ sub display_T {
       my %hash;
       @hash{ qw(cxn id db query time user host) }
          = @{$_}{ qw(cxn mysql_thread_id db query_text active_secs user hostname) };
+      $hash{query} = query_analysis_query_from(
+         \%raw_query_for,
+         $hash{cxn},
+         $hash{id},
+         $hash{query},
+      );
       \%hash;
    } @{$rows_for{innodb_transactions}};
 
@@ -10098,6 +10117,21 @@ sub analyze_query {
       print "\n";
       $action = pause('Press e to explain, a to analyze, j for JSON, t for TREE, f for full query, o for optimized query');
    } while ( exists($actions{$action}) );
+}
+
+# query_analysis_key {{{3
+sub query_analysis_key {
+   my ( $cxn, $id ) = @_;
+   return join("\0", defined $cxn ? $cxn : '', defined $id ? $id : '');
+}
+
+# query_analysis_query_from {{{3
+sub query_analysis_query_from {
+   my ( $raw_query_for, $cxn, $id, $fallback ) = @_;
+   my $key = query_analysis_key($cxn, $id);
+   return $raw_query_for->{$key}
+      if exists $raw_query_for->{$key} && defined $raw_query_for->{$key};
+   return $fallback;
 }
 
 # inc {{{3

--- a/innotop.spec
+++ b/innotop.spec
@@ -3,7 +3,7 @@
 #
 Name:      innotop
 Summary:   A MySQL and InnoDB monitor program.
-Version:   1.16.0
+Version:   1.16.1
 Release:   1%{?dist}
 Vendor:    Baron Schwartz <baron@percona.com>
 Packager:  Frederic Descamps <lefred@percona.com>
@@ -122,6 +122,9 @@ find %{buildroot}%{_prefix}             \
 %defattr(-,root,root)
 
 %changelog
+* Fri Jun 05 2026 Innotop Developers <eslocombe@gmail.com> - 1.16.1-1
+ - Keep raw query text for EXPLAIN actions when display sanitization replaces literals
+
 * Thu May 21 2026 Innotop Developers <eslocombe@gmail.com> - 1.16.0-1
  - Rework query EXPLAIN compatibility for modern MySQL
  - Add runtime EXPLAIN ANALYZE support in query analysis

--- a/t/Explain.t
+++ b/t/Explain.t
@@ -34,7 +34,7 @@ require "innotop";
       return bless { NAME_lc => $columns, rows => $rows, pos => 0 }, $class;
    }
    sub fetchrow_hashref {
-      my ( $self ) = @_;
+      my ( $self, undef ) = @_;
       return if $self->{pos} >= @{ $self->{rows} };
       return $self->{rows}->[ $self->{pos}++ ];
    }
@@ -120,6 +120,56 @@ rewrite_is(
    0,
    'SELECT `from` FROM src WHERE txt = "INSERT INTO x SELECT y"',
    'quoted strings and identifiers in SELECT',
+);
+
+my $cyrillic_regexp_query =
+   "SELECT COUNT(*) FROM sample_texts WHERE COALESCE(body, '') REGEXP '[А-Яа-я]' AND COALESCE(body, '') NOT REGEXP '[A-Za-z]'";
+
+rewrite_is(
+   $cyrillic_regexp_query,
+   0,
+   $cyrillic_regexp_query,
+   'SELECT with non-ASCII REGEXP literal',
+);
+
+rewrite_is(
+   "SELECT COUNT(*) FROM sample_texts WHERE BINARY body REGEXP '[A-Z]'",
+   0,
+   "SELECT COUNT(*) FROM sample_texts WHERE BINARY body REGEXP '[A-Z]'",
+   'SELECT with BINARY string operator',
+);
+
+rewrite_is(
+   "SELECT COUNT(*) FROM sample_texts WHERE body REGEXP BINARY '[A-Z]'",
+   0,
+   "SELECT COUNT(*) FROM sample_texts WHERE body REGEXP BINARY '[A-Z]'",
+   'SELECT with REGEXP BINARY operator',
+);
+
+rewrite_is(
+   "SELECT CAST(body AS BINARY) FROM sample_texts WHERE id = 1",
+   0,
+   "SELECT CAST(body AS BINARY) FROM sample_texts WHERE id = 1",
+   'SELECT with CAST AS BINARY',
+);
+
+rewrite_is(
+   "SELECT STRING_TO_VECTOR('[1, 2, 3]') AS embedding",
+   0,
+   "SELECT STRING_TO_VECTOR('[1, 2, 3]') AS embedding",
+   'SELECT with MySQL VECTOR literal helper',
+);
+
+rewrite_is(
+   "CREATE TABLE vector_dst (embedding VECTOR(3)) AS SELECT STRING_TO_VECTOR('[1, 2, 3]') AS embedding",
+   1,
+   "SELECT STRING_TO_VECTOR('[1, 2, 3]') AS embedding",
+   'CREATE TABLE with MySQL VECTOR column rewrites SELECT part',
+);
+
+rewrite_is_undef(
+   "CREATE TABLE vector_dst (embedding VECTOR(3))",
+   'CREATE TABLE with MySQL VECTOR column and no SELECT',
 );
 
 rewrite_is_undef(
@@ -279,6 +329,91 @@ is(
    "EXPLAIN EXTENDED\nSELECT 1",
    'MariaDB optimized query keeps EXPLAIN EXTENDED',
 );
+
+my @raw_traditional_cases = (
+   [ '5.0.96',          "EXPLAIN\n$cyrillic_regexp_query" ],
+   [ '5.7.44',          "EXPLAIN PARTITIONS\n$cyrillic_regexp_query" ],
+   [ '8.0.45',          "EXPLAIN FORMAT=TRADITIONAL\n$cyrillic_regexp_query" ],
+   [ '9.7.0',           "EXPLAIN FORMAT=TRADITIONAL\n$cyrillic_regexp_query" ],
+   [ '10.11.0-MariaDB', "EXPLAIN PARTITIONS\n$cyrillic_regexp_query" ],
+);
+
+foreach my $case ( @raw_traditional_cases ) {
+   my ( $version, $expected ) = @$case;
+   is(
+      explain_sql_for(dbh_for($version), $cyrillic_regexp_query, 'TRADITIONAL'),
+      $expected,
+      "$version traditional EXPLAIN keeps raw non-ASCII REGEXP literal",
+   );
+}
+
+foreach my $version ( qw(8.0.45 9.7.0 10.11.0-MariaDB) ) {
+   is(
+      explain_sql_for(dbh_for($version), $cyrillic_regexp_query, 'JSON'),
+      "EXPLAIN FORMAT=JSON\n$cyrillic_regexp_query",
+      "$version JSON EXPLAIN keeps raw non-ASCII REGEXP literal",
+   );
+}
+
+foreach my $version ( qw(8.0.45 9.7.0) ) {
+   is(
+      explain_sql_for(dbh_for($version), $cyrillic_regexp_query, 'TREE'),
+      "EXPLAIN FORMAT=TREE\n$cyrillic_regexp_query",
+      "$version TREE EXPLAIN keeps raw non-ASCII REGEXP literal",
+   );
+
+   is(
+      explain_analyze_sql_for(dbh_for($version), $cyrillic_regexp_query),
+      "EXPLAIN ANALYZE FORMAT=TREE\n$cyrillic_regexp_query",
+      "$version EXPLAIN ANALYZE keeps raw non-ASCII REGEXP literal",
+   );
+}
+
+is(
+   explain_analyze_sql_for(dbh_for('8.0.18'), $cyrillic_regexp_query),
+   "EXPLAIN ANALYZE\n$cyrillic_regexp_query",
+   'MySQL 8.0.18 EXPLAIN ANALYZE keeps raw non-ASCII REGEXP literal',
+);
+
+my @raw_optimized_cases = (
+   [ '5.7.44',          "EXPLAIN EXTENDED\n$cyrillic_regexp_query" ],
+   [ '8.0.45',          "EXPLAIN FORMAT=TRADITIONAL\n$cyrillic_regexp_query" ],
+   [ '9.7.0',           "EXPLAIN FORMAT=TRADITIONAL\n$cyrillic_regexp_query" ],
+   [ '10.11.0-MariaDB', "EXPLAIN EXTENDED\n$cyrillic_regexp_query" ],
+);
+
+foreach my $case ( @raw_optimized_cases ) {
+   my ( $version, $expected ) = @$case;
+   is(
+      explain_sql_for_optimized_query(dbh_for($version), $cyrillic_regexp_query),
+      $expected,
+      "$version optimized query EXPLAIN keeps raw non-ASCII REGEXP literal",
+   );
+}
+
+is(
+   explain_analyze_sql_for(dbh_for('10.11.0-MariaDB'), $cyrillic_regexp_query),
+   "ANALYZE\n$cyrillic_regexp_query",
+   'MariaDB ANALYZE keeps raw non-ASCII REGEXP literal',
+);
+
+{
+   my $raw_query = "SELECT COUNT(*) FROM sample_texts WHERE body REGEXP '[А-Яа-я]'";
+   my $display_query = no_ctrl_char($raw_query);
+   my %raw_query_for = ( query_analysis_key('test-cxn', 123) => $raw_query );
+
+   isnt($display_query, $raw_query, 'screen query is sanitized for display');
+   is(
+      query_analysis_query_from(\%raw_query_for, 'test-cxn', 123, $display_query),
+      $raw_query,
+      'query analysis prefers raw processlist query over sanitized display query',
+   );
+   is(
+      query_analysis_query_from(\%raw_query_for, 'test-cxn', 124, $display_query),
+      $display_query,
+      'query analysis falls back to display query without a raw match',
+   );
+}
 
 my %use_sql_for = (
    '0'                 => 'USE `0`',


### PR DESCRIPTION
Fixes query analysis actions using display-sanitized SQL when `no_ctrl_char` replaces non-ASCII string literals with `[BINARY]`.

The visible processlist/transaction tables still sanitize query text for terminal safety, but EXPLAIN, JSON/TREE EXPLAIN, EXPLAIN ANALYZE, optimized query output, and full query display now use the original raw SQL.

  ## Changes
  - Preserve raw query text for query analysis in `Q` processlist mode.
  - Preserve raw transaction query text for query analysis in `T` mode.
  - Keep display sanitization unchanged.
  - Add regression coverage for:
    - non-ASCII `REGEXP` literals
    - `BINARY`, `REGEXP BINARY`, and `CAST(... AS BINARY)` SQL forms
    - MySQL 9.7 `VECTOR` syntax
    - MySQL 5.0, 5.7, 8.0, 9.7 EXPLAIN paths
    - MariaDB legacy EXPLAIN/ANALYZE paths
